### PR TITLE
Update for update notice

### DIFF
--- a/Plugins/BDfunctionsDevilBro.js
+++ b/Plugins/BDfunctionsDevilBro.js
@@ -12,6 +12,13 @@ BDfunctionsDevilBro.loadMessage = function (pluginName, oldVersion) {
 				var oldNmbrs = oldVersion.split(".").map(Number); 
 				var newNmbrs = newVersion.split(".").map(Number); 
 				if (oldNmbrs.length == newNmbrs.length) {
+					var notice = $('#' + pluginName + '-notice');
+					if (notice.length) {
+						if (notice.next('.separator').length) notice.next().remove();
+						else if (notice.prev('.separator').length) notice.prev().remove();
+						notice.remove();
+					}
+					if (!$('#outdatedPlugins').children('span').length) $('#pluginNoticeDismiss').click();
 					for (var i = 0; i < oldNmbrs.length; i++) {
 						if (newNmbrs[i] > oldNmbrs[i]) {
 							var noticeCSS = `
@@ -37,11 +44,11 @@ BDfunctionsDevilBro.loadMessage = function (pluginName, oldVersion) {
 								});
 							}
 							var pluginNoticeID = pluginName + "-notice";
-							var pluginNoticeElement = $('<span id="' + pluginNoticeID + '">');
-							pluginNoticeElement.html('<a href="' + downloadUrl + '" target="_blank">' + pluginName + '</a>');
 							if (!$('#'+pluginNoticeID).length) {
+								var pluginNoticeElement = $('<span id="' + pluginNoticeID + '">');
+								pluginNoticeElement.html('<a href="' + downloadUrl + '" target="_blank">' + pluginName + '</a>');
 								if ($('#outdatedPlugins').children('span').length) {
-									pluginNoticeElement.html(", " + pluginNoticeElement.html());
+									$('#outdatedPlugins').append("<span class='separator'>, </span>");
 								}
 								$('#outdatedPlugins').append(pluginNoticeElement);
 							}


### PR DESCRIPTION
The first section of green in the diff removes the current notice if it exists (this is really nice for people with RNM). Then it also checks if that was the last update in the list and clicks the `x` button for the user if there are no more plugins with updates.

The section section in the diff just changes how commas are handled. Commas are now in their own `<span>` with class `separator`, some people requested this for themeing so the update removal and addition take that into account. (It would also prevent the case where it is displayed as `plugin1, plugin2` but plugin1 is updated and removed would show `, plugin2`) 