### PR TITLE
bug fixes with settings and itranslate

### DIFF
--- a/Plugins/GoogleTranslateOption/GoogleTranslateOption.plugin.js
+++ b/Plugins/GoogleTranslateOption/GoogleTranslateOption.plugin.js
@@ -15,12 +15,12 @@ var GoogleTranslateOption = (_ => {
 	};
 	
 	const translationEngines = {
-		googleapi: 					{name:"GoogleApi",		funcName:"googleApiTranslate",		languages: ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","my","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","ne","no","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","sw","sv","tg","ta","te","th","tr","uk","ur","uz","vi","cy","xh","yi","yo","zu"]},
-		google: 					{name:"Google",			funcName:"googleTranslate",			languages: ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","my","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","ne","no","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","sw","sv","tg","ta","te","th","tr","uk","ur","uz","vi","cy","xh","yi","yo","zu"]},
-		itranslate: 				{name:"iTranslate",		funcName:"iTranslateTranslate",		languages: ["af","sq","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","zh-TW","hr","cs","da","nl","en","eo","et","fil","fi","fr","gl","ka","de","el","gu","ht","he","ha","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","ko","lo","la","lv","lt","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","fa","pl","pt-BR","pt-PT","pa","ro","ru","sr","st","si","sk","sl","so","es","su","sw","sv","tg","ta","te","th","tr","uk","ur","uz","vi","we","yi","yo","zu"]},
+		googleapi: 					{name:"GoogleApi",		funcName:"googleApiTranslate",		languages: ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","tl","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","rw","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","or","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","su","sw","sv","tg","ta","tt","te","th","tr","tk","uk","ur","ug","uz","vi","cy","xh","yi","yo","zu"]},
+		google: 					{name:"Google",			funcName:"googleTranslate",			languages: ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","tl","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","rw","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","or","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","su","sw","sv","tg","ta","tt","te","th","tr","tk","uk","ur","ug","uz","vi","cy","xh","yi","yo","zu"]},
+		itranslate: 				{name:"iTranslate",		funcName:"iTranslateTranslate",		languages: ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","zh-TW","pt-BR","pt-PT","co","hr","he","cs","da","nl","en","eo","et","tl","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","rw","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","or","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","su","sw","sv","tg","ta","tt","te","th","tr","tk","uk","ur","ug","uz","vi","cy","xh","yi","yo","zu"]},
 		yandex: 					{name:"Yandex",			funcName:"yandexTranslate",			languages: ["af","sq","am","ar","hy","az","ba","eu","be","bn","bs","bg","my","ca","ceb","zh","hr","cs","da","nl","en","eo","et","fi","fr","gl","ka","de","el","gu","ht","he","hi","hu","is","id","ga","it","ja","jv","kn","kk","km","ko","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mhr","mn","ne","no","pap","fa","pl","pt","pa","ro","ru","gd","sr","si","sk","sl","es","su","sw","sv","tl","tg","ta","tt","te","th","tr","udm","uk","ur","uz","vi","cy","xh","yi"]}
 	};
-	
+
 	var languages, translating, isTranslating, translatedMessages;
 	
 	return class GoogleTranslateOption {
@@ -35,6 +35,7 @@ var GoogleTranslateOption = (_ => {
 		constructor () {
 			this.changelog = {
 				"added":[["GoogleApi","Added a new way faster Google Api that uses a translation API provided by Google, which does not rely on using an invisible brower window to translate the text, this API is limited to 100 requests per hour, so you might get rate limited quickly"]],
+				"fixed":[["iTranslate","Fixed the iTranslate engine not translating text"]],
 				"improved":[["New Library Structure & React","Restructured my Library and switched to React rendering instead of DOM manipulation"]]
 			};
 
@@ -429,7 +430,7 @@ var GoogleTranslateOption = (_ => {
 							input = input == "auto" ? "en" : input;
 							BDFDB.DataUtils.save(output, this, "choices", "input" + place);
 							BDFDB.DataUtils.save(input, this, "choices", "output" + place);
-							for (let selectIns of BDFDB.ReactUtils.findOwner(BDFDB.ReactUtils.findOwner(e._targetInst, {name:["BDFDB_Popout", "BDFDB_SettingsPanel"], up:true}), {name:"BDFDB_Select", all:true, noCopies:true})) if (selectIns && selectIns.props && selectIns.props.id && this.defaults.choices[selectIns.props.id].place == place) {
+							for (let selectIns of BDFDB.ReactUtils.findOwner(BDFDB.ReactUtils.findOwner(e._targetInst, {name:["BDFDB_Popout", "BDFDB_SettingsPanel"], up:true}), {name:"BDFDB_Select", all:true, noCopies:true})) if (selectIns && selectIns.props && selectIns.props.id && this.defaults.choices[selectIns.props.id] && this.defaults.choices[selectIns.props.id].place == place) {
 								selectIns.props.value = this.defaults.choices[selectIns.props.id].direction == "input" ? output : input;
 								BDFDB.ReactUtils.forceUpdate(selectIns);
 							}
@@ -643,7 +644,7 @@ var GoogleTranslateOption = (_ => {
 					method: "POST",
 					url: "https://web-api.itranslateapp.com/v3/texts/translate",
 					headers: {
-						"API-KEY": "d2aefeac9dc661bc98eebd6cc12f0b82"
+						"API-KEY": data.engine.APIkey || "d2aefeac9dc661bc98eebd6cc12f0b82"
 					},
 					body: JSON.stringify({
 						source: {
@@ -658,9 +659,9 @@ var GoogleTranslateOption = (_ => {
 					if (!error && response && response.statusCode == 200) {
 						try {
 							result = JSON.parse(result);
-							if (!data.specialcase && result.source && result.source.detected && languages[result.source.detected]) {
-								data.input.name = languages[result.source.detected].name;
-								data.input.ownlang = languages[result.source.detected].ownlang;
+							if (!data.specialcase && result.source && result.source.dialect && languages[result.source.dialect]) {
+								data.input.name = languages[result.source.dialect].name;
+								data.input.ownlang = languages[result.source.dialect].ownlang;
 							}
 							callback(result.target.text);
 						}
@@ -673,7 +674,7 @@ var GoogleTranslateOption = (_ => {
 				});
 			};
 			if (data.engine.APIkey) translate();
-			else BDFDB.LibraryRequires.request("https://www.itranslate.com/themes/itranslate2016/assets/webapp/js/main.js", {gzip: true}, (error, response, result) => {
+			else BDFDB.LibraryRequires.request("https://www.itranslate.com/js/webapp/main.js", {gzip: true}, (error, response, result) => {
 				if (!error && result) {
 					let APIkey = /var API_KEY = "(.+)"/.exec(result);
 					if (APIkey) {


### PR DESCRIPTION
### Bug Fixes
- Fixed an error that occurred when swapping input/output language selectors.
```console
8e225751b5d02f707bd5.js:16 Uncaught TypeError: Cannot read property 'place' of undefined
    at Object.onClick (VM1514 C:\Users\BannerBomb\AppData\Roaming\BetterDiscord\plugins\GoogleTranslateOption.plugin.js:432)
```
- Fixed iTranslate not translating due to the url on line 677 changing.
- Restructed lines 662-665 to the new iTranslate api structure.

### Changes
I changed the input languages array for iTranslate on line 20 because what I have now is all iTranslate supports for their input/output languages currently. I have checked and all of them are also listed within `BDFDB.LanguageUtils.languages`. The reason I edited the language list for iTranslate is because if you use a language that isn't supported by their service, iTranslate will fallback to Google Translate's api instead meaning it also supports Google Translates languages also.
I have also added in the other additional supported languages for google translate that weren't already present.

I have tested the changes before I made the PR to make sure everything else would still work properly.