### PR TITLE
[Bugfix] [BasicBackground] Fix the position of avatars in chat

### DIFF
--- a/Themes/BasicBackground/BasicBackground.css
+++ b/Themes/BasicBackground/BasicBackground.css
@@ -819,7 +819,7 @@ body:before {
 	background-color: rgba(var(--vaccentcolor), calc(0.3 * var(--vusechatbubbles)));
 }
 .avatar-1BDn8e {
-	left: calc(-70px * var(--vusechatbubbles) + 16px);
+	left: calc(-78px * var(--vusechatbubbles) + 16px);
 }
 .container-3FojY8 .avatar-1BDn8e {
 	left: calc(-10px * var(--vusechatbubbles));


### PR DESCRIPTION
Moves avatars to their correct location; to the left of the message instead of inside the message.

**Without fix**
![image](https://user-images.githubusercontent.com/17354045/75624795-8e1ea980-5baf-11ea-979c-2b747c49c8aa.png)

**With fix**
![image](https://user-images.githubusercontent.com/17354045/75624807-a8588780-5baf-11ea-8478-195def2dfbf9.png)

Resolves #375 