### PR TITLE
Correct link to DiscordRecolor

### DIFF
--- a/Themes/README.md
+++ b/Themes/README.md
@@ -8,7 +8,7 @@
 
  - [Basic Background](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/BasicBackground) - Use a background image in Discord without greatly altering the basic look of Discord
  - [Blurple Recolor](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/BlurpleRecolor) - Replace discords native blurple with your own color, change color in themefile
- - [Discord Recolor](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/BlurpleRecolor) - Easily customize discords native look
+ - [Discord Recolor](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/DiscordRecolor) - Easily customize discords native look
  - [Emoji Replace](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/EmojiReplace) - Replace discords emojis with emojis of a provider of your choice
  - [Full Theme Dark](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/FullThemeDark) - Fix all unthemed sections in the native dark theme of discord
  - [Server Columns](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/ServerColumns) - Change the Server List to a gridlike container to allow servers to be displayed in columns. Amount of columns can be set in the .theme.css file


### PR DESCRIPTION
This small pull request just corrects an incorrect link in the Themes README file.