### PR TITLE
(GoogleSearchReplace)- searx.me is no longer an active search site

### DIFF
--- a/Plugins/GoogleSearchReplace/GoogleSearchReplace.plugin.js
+++ b/Plugins/GoogleSearchReplace/GoogleSearchReplace.plugin.js
@@ -66,7 +66,7 @@ module.exports = (_ => {
 						Quora: 				{value:true, 	name:"Quora", 				url:"https://www.quora.com/search?q=" + textUrlReplaceString},
 						Qwant: 				{value:true, 	name:"Qwant", 				url:"https://www.qwant.com/?t=all&q=" + textUrlReplaceString},
 						UrbanDictionary: 	{value:true, 	name:"Urban Dictionary", 	url:"https://www.urbandictionary.com/define.php?term=" + textUrlReplaceString},
-						Searx: 				{value:true, 	name:"Searx", 				url:"https://searx.me/?q=" + textUrlReplaceString},
+						Searx: 				{value:true, 	name:"Searx", 				url:"https://searx.info/?q=" + textUrlReplaceString},
 						WolframAlpha:		{value:true, 	name:"Wolfram Alpha", 		url:"https://www.wolframalpha.com/input/?i=" + textUrlReplaceString},
 						Yandex: 			{value:true, 	name:"Yandex", 				url:"https://yandex.com/search/?text=" + textUrlReplaceString},
 						Yahoo: 				{value:true, 	name:"Yahoo", 				url:"https://search.yahoo.com/search?p=" + textUrlReplaceString},


### PR DESCRIPTION
Sorry, first time I've ever cloned, branched, committed, pulled, etc.
searx.me is no longer used for searching, I replaced it with searx.info.