### PR TITLE
[Bugfix] Boost Perks Notice Clicking

### DIFF
--- a/Themes/BlurpleRecolor/BlurpleRecolor.css
+++ b/Themes/BlurpleRecolor/BlurpleRecolor.css
@@ -130,6 +130,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
+	pointer-events:none;
 }
 .channelNotice-1-XFjC.quickswitcher-35bYg4 {
 	background: transparent;


### PR DESCRIPTION
The ".channelNotice-1-XFjC"  (channel notice) wasnt letting users click on the "X" (Close) and the "See Levels & Perks" button.
By adding "pointer-events:none;" this is fixed. If theres any other issue where a ::before / ::after thing is over the buttons and not letting click them adding this should fix them, just found this one