### PR TITLE
Added "DoubleBack" Setting

### DIFF
--- a/Plugins/SpotifyControls/SpotifyControls.plugin.js
+++ b/Plugins/SpotifyControls/SpotifyControls.plugin.js
@@ -214,7 +214,7 @@ module.exports = (_ => {
 												playerSize: playerSize,
 												disabled: socketDevice.device.is_restricted,
 												onClick: _ => {
-													if (previousIsClicked) {
+													if (previousIsClicked || !settings.doubleBack) {
 														previousIsClicked = false;
 														this.request(socketDevice.socket, socketDevice.device, "previous");
 													}
@@ -412,7 +412,8 @@ module.exports = (_ => {
 				
 				this.defaults = {
 					settings: {
-						addTimeline: 		{value: true,		description: "Show the song timeline in the controls"}
+						addTimeline: 		{value: true,		description: "Show the song timeline in the controls"},
+						doubleBack: 		{value: true,       description: "Force user to press back button twice to go to previous track"}
 					},
 					buttonConfigs: {
 						share: 				{value: {small: false, big: true},		icons: [""],						description: "Share"},


### PR DESCRIPTION
Added the ability to change the functionality regarding pressing back button twice. I wanted this feature for myself, so I thought it would be worthwhile to put up a PR for anyone else if they want to use it.

With the setting enabled, original functionality is ensured.
With the setting disabled, the back button will always default to going to the previous song.

I would like to change the functionality to behave more like the spotify desktop app, where it relies on the songs current position instead of how fast you press the back button. Didn't have enough of a chance to look into it yet, but thought I'd put this PR up anyway.

![image](https://user-images.githubusercontent.com/20635452/105937054-a4282a80-6009-11eb-9d4a-20d440224e58.png)
