### PR TITLE
Allow S.team links to open in steam

### DIFF
--- a/Plugins/SteamProfileLink/SteamProfileLink.plugin.js
+++ b/Plugins/SteamProfileLink/SteamProfileLink.plugin.js
@@ -74,7 +74,7 @@ module.exports = (_ => {
 		}
 	} : (([Plugin, BDFDB]) => {
 		const urls = {
-			steam: ["https://steamcommunity.", "https://help.steampowered.", "https://store.steampowered.", "a.akamaihd.net/"]
+			steam: ["https://steamcommunity.", "https://help.steampowered.", "https://store.steampowered.", "https://s.team/, "a.akamaihd.net/"]
 		};
 		
 		return class SteamProfileLink extends Plugin {


### PR DESCRIPTION
S.team links are used in friend links and other shortened steam links too.

I have also tested it and it seems to work fine.