### PR TITLE
Fixed text replacement in FriendNotifications

### DIFF
--- a/Plugins/FriendNotifications/FriendNotifications.plugin.js
+++ b/Plugins/FriendNotifications/FriendNotifications.plugin.js
@@ -874,7 +874,7 @@ module.exports = (_ => {
 									}
 								};
 								if (observedUsers[id][status.name] == notificationTypes.DESKTOP.value) {
-									let desktopString = string.replace(/\$user/g, `${name}${this.settings.general.showDiscriminator ? ("#" + user.discriminator) : ""}`).replace(/\$status/g, statusName).replace(/\$statusOld/g, oldStatusName);
+									let desktopString = string.replace(/\$user/g, `${name}${this.settings.general.showDiscriminator ? ("#" + user.discriminator) : ""}`).replace(/\$statusOld/g, oldStatusName).replace(/\$status/g, statusName);
 									if (status.activity) desktopString = desktopString.replace(/\$song|\$game/g, status.activity.name || status.activity.details || "").replace(/\$artist|\$custom/g, [status.activity.emoji && status.activity.emoji.name, status.activity.state].filter(n => n).join(" ") || "");
 									if (status.mobile) desktopString += " (mobile)";
 									let notificationSound = this.settings.notificationSounds["desktop" + status.name] || {};


### PR DESCRIPTION
Current notifications using `statusOld` would be shown as the new status with `Old` appended to it.
Changed the order of `.replace` to replace `statusOld` before `status`.