### PR TITLE
Ignore spaces when searching through PluginRepo and ThemeRepo

### DIFF
--- a/Plugins/PluginRepo/PluginRepo.plugin.js
+++ b/Plugins/PluginRepo/PluginRepo.plugin.js
@@ -148,8 +148,8 @@ module.exports = (_ => {
 				if (!this.props.outdated)		plugins = plugins.filter(plugin => plugin.state != pluginStates.OUTDATED);
 				if (!this.props.downloadable)	plugins = plugins.filter(plugin => plugin.state != pluginStates.DOWNLOADABLE);
 				if (searchString) 	{
-					let usedSearchString = searchString.toUpperCase();
-					plugins = plugins.filter(plugin => plugin.search.indexOf(usedSearchString) > -1);
+					let usedSearchString = searchString.toUpperCase().replace(" ", "");
+					plugins = plugins.filter(plugin => plugin.search.replace(" ", "").indexOf(usedSearchString) > -1);
 				}
 				
 				BDFDB.ArrayUtils.keySort(plugins, this.props.sortKey.toLowerCase());

--- a/Plugins/ThemeRepo/ThemeRepo.plugin.js
+++ b/Plugins/ThemeRepo/ThemeRepo.plugin.js
@@ -150,8 +150,8 @@ module.exports = (_ => {
 				if (!this.props.outdated)		themes = themes.filter(theme => theme.state != themeStates.OUTDATED);
 				if (!this.props.downloadable)	themes = themes.filter(theme => theme.state != themeStates.DOWNLOADABLE);
 				if (searchString) 	{
-					let usedSearchString = searchString.toUpperCase();
-					themes = themes.filter(theme => theme.search.indexOf(usedSearchString) > -1);
+					let usedSearchString = searchString.toUpperCase().replace(" ", "");
+					themes = themes.filter(theme => theme.search.replace(" ", "").indexOf(usedSearchString) > -1);
 				}
 				
 				BDFDB.ArrayUtils.keySort(themes, this.props.sortKey.toLowerCase());


### PR DESCRIPTION
I noticed that I search for plugins like "Spotify Controls" and it doesn't return any results. This will remove all spaces from the search.