### PR TITLE
Fix Steam images opening in default browser instead of in-app

### DIFF
--- a/Plugins/OpenSteamLinksInApp/OpenSteamLinksInApp.plugin.js
+++ b/Plugins/OpenSteamLinksInApp/OpenSteamLinksInApp.plugin.js
@@ -74,7 +74,7 @@ module.exports = (_ => {
 		}
 	} : (([Plugin, BDFDB]) => {
 		const urls = {
-			steam: ["https://steamcommunity.", "https://help.steampowered.", "https://store.steampowered.", "https://s.team/", "a.akamaihd.net/"]
+			steam: ["https://steamcommunity.", "https://help.steampowered.", "https://store.steampowered.", "https://s.team/"]
 		};
 		
 		return class OpenSteamLinksInApp extends Plugin {


### PR DESCRIPTION
This fixes #866, by removing `a.akamaihd.net` from the list of domains to open in Steam.