### PR TITLE
Fixed CharCounter

### DIFF
--- a/Library/0BDFDB.plugin.js
+++ b/Library/0BDFDB.plugin.js
@@ -5080,7 +5080,7 @@ module.exports = (_ => {
 			}
 			render() {
 				let string = this.getCounterString();
-				if (!string) return null;
+				if (!string) string = "";
 				BDFDB.TimeUtils.timeout(_ => string != this.getCounterString() && BDFDB.ReactUtils.forceUpdate(this));
 				return BDFDB.ReactUtils.createElement("div", BDFDB.ObjectUtils.exclude(Object.assign({}, this.props, {
 					className: BDFDB.DOMUtils.formatClassName(BDFDB.disCN.charcounter, this.props.className),


### PR DESCRIPTION
Returning null on the render makes it impossible to find the node, which kills the whole process since you need it to query for the refElement

There's probably a better fix than just making string = ""