### PR TITLE
Fix: Unable to send pictures

### DIFF
--- a/Plugins/Translator/Translator.plugin.js
+++ b/Plugins/Translator/Translator.plugin.js
@@ -642,7 +642,7 @@ module.exports = (_ => {
 			
 			processChannelTextAreaForm (e) {
 				BDFDB.PatchUtils.patch(this, e.instance, "handleSendMessage", {instead: e2 => {
-					if (this.isTranslationEnabled(e.instance.props.channel.id)) {
+					if (this.isTranslationEnabled(e.instance.props.channel.id)   && e2.methodArguments[0] != "") {
 						e2.stopOriginalMethodCall();
 						this.translateText(e2.methodArguments[0], messageTypes.SENT, (translation, input, output) => {
 							translation = !translation ? e2.methodArguments[0] : (this.settings.general.sendOriginalMessage ? (translation + "\n\n> *" + e2.methodArguments[0].split("\n").join("*\n> *") + "*") : translation);


### PR DESCRIPTION
Fix: When translation is turned on, pictures or files cannot be sent, and translation must be temporarily stopped before files or pictures can be sent