### PR TITLE
Fixed typo

### DIFF
--- a/Library/_res/0BDFDB.data.json
+++ b/Library/_res/0BDFDB.data.json
@@ -4795,7 +4795,7 @@
 			"order": "Sekvens",
 			"outdated": "Föråldrad",
 			"please_wait": "Vänligen vänta",
-			"right": "Rätt",
+			"right": "Höger",
 			"save_fail": "{{var0}} kan inte sparas",
 			"save_success": "{{var0}} har sparats",
 			"send": "Skicka {{var0}}",


### PR DESCRIPTION
"Höger" is how you say "[to the] right" in Swedish.