### PR TITLE
Separate Choice for each Dicord builds

### DIFF
--- a/Plugins/NotificationSounds/NotificationSounds.plugin.js
+++ b/Plugins/NotificationSounds/NotificationSounds.plugin.js
@@ -689,7 +689,9 @@ module.exports = (_ => {
 			}
 
 			loadChoices () {
-				let loadedChoices = BDFDB.DataUtils.load(this, "choices");
+				let discordBuild = BDFDB.DiscordUtils.getBuild();
+				let choicesName = discordBuild === "stable" ? "choices" : `choices_${discordBuild}`;
+				let loadedChoices = BDFDB.DataUtils.load(this, choicesName);
 				for (let type in types) {
 					let choice = loadedChoices[type] || {}, soundFound = false;
 					for (let category in audios) if (choice.category == category) for (let sound in audios[category]) if (choice.sound == sound) {
@@ -710,7 +712,9 @@ module.exports = (_ => {
 
 			saveChoice (type, play) {
 				if (!choices[type]) return;
-				BDFDB.DataUtils.save(choices[type], this, "choices", type);
+				let discordBuild = BDFDB.DiscordUtils.getBuild();
+				let choicesName = discordBuild === "stable" ? "choices" : `choices_${discordBuild}`;
+				BDFDB.DataUtils.save(choices[type], this, choicesName, type);
 				if (play) {
 					this.SettingsUpdated = true;
 					this.playAudio(type);


### PR DESCRIPTION
Discord builds (Stable, Ptb, Canary) will no longer share notification sound choices for each client.
This allows each client to use a separate notification sound.
![NotificationSoundsPR](https://user-images.githubusercontent.com/16362824/173840353-297f4704-e3b5-470c-a29f-c22f816269b4.jpg)

