### PR TITLE
ImageUtilities - Don't force scale up smaller images

### DIFF
--- a/Plugins/ImageUtilities/ImageUtilities.plugin.js
+++ b/Plugins/ImageUtilities/ImageUtilities.plugin.js
@@ -1228,7 +1228,9 @@ module.exports = (_ => {
 						let mRects = BDFDB.DOMUtils.getRects(document.querySelector(BDFDB.dotCNC.messageaccessory + BDFDB.dotCN.messagecontents));
 						let mwRects = BDFDB.DOMUtils.getRects(document.querySelector(BDFDB.dotCN.messagewrapper));
 						if (mRects.width || mwRects.width) {
-							let ratio = (mRects.width || (mwRects.width - 120)) / e.instance.props.width;
+							let ratio = 1;
+							if (e.instance.props.width >= (mRects.width || (mwRects.width - 120)))
+								ratio = (mRects.width || (mwRects.width - 120)) / e.instance.props.width;
 							let width = Math.round(ratio * e.instance.props.width);
 							let height = Math.round(ratio * e.instance.props.height);
 							if (height > (aRects.height * 0.66)) {


### PR DESCRIPTION
This resolves the issue of tiny images, like 20x20px being scaled up to huge sizes when you have the resize messages option enabled.

With the PR, images are displayed at their original size and only clamped down by the ratio if the size exceeds limits