### PR TITLE
ImageUtilities: Use fallback URL if response type is text/html 

### DIFF
--- a/Plugins/ImageUtilities/ImageUtilities.plugin.js
+++ b/Plugins/ImageUtilities/ImageUtilities.plugin.js
@@ -1420,7 +1420,7 @@ module.exports = (_ => {
 				url = url.startsWith("/assets") ? (window.location.origin + url) : url;
 				BDFDB.LibraryRequires.request(url, {agentOptions: {rejectUnauthorized: false}, encoding: null}, (error, response, body) => {
 					let type = this.isValid(url, "video") ? BDFDB.LanguageUtils.LanguageStrings.VIDEO : BDFDB.LanguageUtils.LanguageStrings.IMAGE;
-					if (error || response.statusCode != 200) {
+					if (error || response.statusCode != 200 || response.headers["content-type"] == "text/html") {
 						if (fallbackUrl) this.downloadFile(fallbackUrl, path, null, alternativeName);
 						else BDFDB.NotificationUtils.toast(this.labels.toast_save_failed.replace("{{var0}}", type).replace("{{var1}}", ""), {type: "danger"});
 					}


### PR DESCRIPTION
When you try to download certain embedded GIFs/Videos, sometimes it attempts to download the full webpage. I have only seen this occur with imgur embedded videos so far