### PR TITLE
Use variable for crown color

### DIFF
--- a/Plugins/StaffTag/StaffTag.plugin.js
+++ b/Plugins/StaffTag/StaffTag.plugin.js
@@ -143,10 +143,10 @@ module.exports = (_ => {
 			
 				this.css = `
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagadminicon} {
-						color: #aaa9ad;
+						color: var(--text-brand);
 					}
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagmanagementicon} {
-						color: #88540b;
+						color: var(--text-danger);
 					}
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagforumcreatoricon},
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagthreadcreatoricon} {


### PR DESCRIPTION
Hello,
This PR use variables for crown color of admin and management.

This also change admin to blurple instead of grey, and management to red instead of dark orange.

**This is new render** :
![Screenshot_20221123_165439](https://user-images.githubusercontent.com/1344792/203591125-e5862520-52d3-4fb7-9174-06b297913794.png)