### PR TITLE
[StaffTag] Use variable for crown color

### DIFF
--- a/Plugins/StaffTag/StaffTag.plugin.js
+++ b/Plugins/StaffTag/StaffTag.plugin.js
@@ -143,10 +143,10 @@ module.exports = (_ => {
 			
 				this.css = `
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagadminicon} {
-						color: #aaa9ad;
+						color: var(--text-muted);
 					}
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagmanagementicon} {
-						color: #88540b;
+						color: var(--status-yellow-660);
 					}
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagforumcreatoricon},
 					${BDFDB.dotCN.memberownericon + BDFDB.dotCN._stafftagthreadcreatoricon} {


### PR DESCRIPTION
Hello,
This PR use variables for crown color of admin and management.

Using variable is great for follow the discord changes and for allow easy theming.

Unlike #2066 this doesn't change the color.
![Screenshot_20221123_184916](https://user-images.githubusercontent.com/1344792/203615421-6328d84e-6d91-4c81-ab32-013dfb8103ac.png)
