### PR TITLE
Update ImageUtilities.plugin.js

### DIFF
--- a/Plugins/ImageUtilities/ImageUtilities.plugin.js
+++ b/Plugins/ImageUtilities/ImageUtilities.plugin.js
@@ -2106,7 +2106,7 @@ module.exports = (_ => {
 							context_copy:						"Copy {{var0}}",
 							context_imageactions:				"Image Actions",
 							context_lenssize:					"Lens Size",
-							context_saveas:						"Save {{var0}} as ...",
+							context_saveas:						"Save {{var0}} to ...",
 							context_searchwith:					"Search {{var0}} with ...",
 							context_videoactions:				"Video Actions",
 							context_view:						"View {{var0}}",


### PR DESCRIPTION
Thought I should come and make a small grammatical fix. When right-click saving to a location, The right click menu says "Save TYPE as". It would make more sense if it said "Save TYPE to". Which I have edited here.