### PR TITLE
Change SpotifyControls container colour to reflect the current theme

### DIFF
--- a/Plugins/SpotifyControls/SpotifyControls.plugin.js
+++ b/Plugins/SpotifyControls/SpotifyControls.plugin.js
@@ -477,6 +477,7 @@ module.exports = (_ => {
 						display: flex;
 						flex-direction: column;
 						justify-content: center;
+						background: var(--bg-overlay-1,var(--background-secondary-alt));
 						min-height: 52px;
 						margin-bottom: 1px;
 						border-bottom: 1px solid var(--background-modifier-accent);


### PR DESCRIPTION
- If the user has a Nitro theme active then the container will reflect this colour aswell.
- The standard light/dark themes are not affected by this change

Two examples of how this looks like if implemented:
![image](https://user-images.githubusercontent.com/24542180/231134343-7f2ad22b-f5e2-4c8c-89a0-d25f6c7e9aa1.png)
