### PR TITLE
Fix tooltip parts appearing after empty tooltip

### DIFF
--- a/Library/_res/0BDFDB.raw.css
+++ b/Library/_res/0BDFDB.raw.css
@@ -1281,7 +1281,7 @@ input[REPLACE_CLASS_input][REPLACE_CLASS_inputerror] {
 	color: #fff;
 }
 [REPLACE_CLASS_tooltip] [REPLACE_CLASS_tooltipcontent]:empty,
-[REPLACE_CLASS_tooltip] [REPLACE_CLASS_tooltipcontent]:empty > * {
+[REPLACE_CLASS_tooltip] [REPLACE_CLASS_tooltipcontent]:empty ~ * {
 	display: none !important;
 }
 [REPLACE_CLASS_tooltip][REPLACE_CLASS_tooltipcustom] [REPLACE_CLASS_tooltipnote],


### PR DESCRIPTION
Minor fix, tooltip pointer was visible while tooltip was empty to the right side of a hovered channel, while using DisplayServersAsChannels.

Default appearance:
![image](https://github.com/mwittrien/BetterDiscordAddons/assets/29710355/8b38457d-ca9a-4403-ae65-3be094e245bf)

With a theme which brings out the contrast:
![image](https://github.com/mwittrien/BetterDiscordAddons/assets/29710355/a22c23d4-bd6b-498e-8962-17e0c080078c)