### PR TITLE
[FIX] - ShowConnections - Connection metadata

### DIFF
--- a/Plugins/ShowConnections/ShowConnections.plugin.js
+++ b/Plugins/ShowConnections/ShowConnections.plugin.js
@@ -2,7 +2,7 @@
  * @name ShowConnections
  * @author DevilBro
  * @authorId 278543574059057154
- * @version 1.1.8
+ * @version 1.1.9
  * @description Shows the connected Accounts of a User in the UserPopout
  * @invite Jx3TjNS
  * @donate https://www.paypal.me/MircoWittrien
@@ -87,7 +87,7 @@ module.exports = (_ => {
 								let provider = BDFDB.LibraryModules.ConnectionProviderUtils.get(c.type);
 								let url = _this.settings.general.openWebpage && provider.getPlatformUserUrl && provider.getPlatformUserUrl(c);
 								let metadata = [];
-								if (_this.settings.general.showDetails && provider.hasMetadata) {
+								if (_this.settings.general.showDetails && provider.hasMetadata && c.metadata) {
 									if (c.metadata.created_at) metadata.push(BDFDB.ReactUtils.createElement("span", {children: BDFDB.LanguageUtils.LanguageStringsFormat("CONNECTIONS_PROFILE_MEMBER_SINCE", (new Date(c.metadata.created_at)).toLocaleDateString("default", {year: "numeric", month: "long", day: "numeric"}))}));
 									let metadataGetter = BDFDB.LibraryModules.ConnectionMetadataUtils["get" + BDFDB.StringUtils.upperCaseFirstChar(c.type)];
 									if (metadataGetter) metadata = metadata.concat(metadataGetter(c.metadata));


### PR DESCRIPTION
Fixed errors due to `c.metadata` is `undefined`.

This bug would result connection elements show "React Component Error".

## Debug log
```
[2023-08-19 21:57:42.892][CONSOLE:ERROR] Cannot read properties of undefined (reading 'created_at')
TypeError: Cannot read properties of undefined (reading 'created_at')
    at eval (betterdiscord://plugins/ShowConnections.plugin.js:93:25)
    at Array.map (<anonymous>)
    at UserConnections.render (betterdiscord://plugins/ShowConnections.plugin.js:88:30)
    at Ds (https://discord.com/assets/c523f20e5a105210fc02.js:1817:100)
    at Rs (https://discord.com/assets/c523f20e5a105210fc02.js:1816:890)
    at gu (https://discord.com/assets/c523f20e5a105210fc02.js:1857:100)
    at Ic (https://discord.com/assets/c523f20e5a105210fc02.js:1849:89)
    at mc (https://discord.com/assets/c523f20e5a105210fc02.js:1849:17)
    at hc (https://discord.com/assets/c523f20e5a105210fc02.js:1848:867)
    at oc (https://discord.com/assets/c523f20e5a105210fc02.js:1845:642)
    at ic (https://discord.com/assets/c523f20e5a105210fc02.js:1844:184)
    at v (https://discord.com/assets/c523f20e5a105210fc02.js:1961:904)
    at C (https://discord.com/assets/c523f20e5a105210fc02.js:1962:267)
    at g.<computed> (https://discord.com/assets/73e2773dff096c1644fc.js:108:1)
    at m (https://discord.com/assets/73e2773dff096c1644fc.js:107:764)
    at MessagePort.M (https://discord.com/assets/73e2773dff096c1644fc.js:107:823)
[2023-08-19 21:57:42.892][CONSOLE:ERROR] [BDFDB] (v3.3.4) Fatal Error: Could not create React Element! TypeError: Cannot read properties of undefined (reading 'created_at')
```

## Screenshots
Before:
![image](https://github.com/mwittrien/BetterDiscordAddons/assets/84374077/37119ac2-f0b9-49aa-9e7f-0e9990336406)