### PR TITLE
removed glitched % symbol in SpotifyControls

### DIFF
--- a/Plugins/SpotifyControls/SpotifyControls.plugin.js
+++ b/Plugins/SpotifyControls/SpotifyControls.plugin.js
@@ -323,7 +323,7 @@ module.exports = (_ => {
 															changeTimeout = BDFDB.TimeUtils.timeout(_ => this.props.draggingVolume && this.request(socketDevice.socket, socketDevice.device, "volume", {
 																volume_percent: currentVolume
 															}), 500);
-															return value + "%";
+															return value;
 														},
 														onValueChange: value => {
 															if (currentVolume == value) return;


### PR DESCRIPTION
Currently the spotify plugin's volume slider appears to have the '%' symbol appear and disappear as it is being moved, this removes the symbol so only the number is shown without the symbol.