### PR TITLE
Fix TopRoleEverywhere

### DIFF
--- a/Plugins/TopRoleEverywhere/TopRoleEverywhere.plugin.js
+++ b/Plugins/TopRoleEverywhere/TopRoleEverywhere.plugin.js
@@ -231,7 +231,7 @@ module.exports = (_ => {
 
 			injectIdTag (children, user, type, config = {}) {
 				if (!BDFDB.ArrayUtils.is(children) || !user) return;
-				children.push(insertIndex, 0, this.createTag({
+				children.push(this.createTag({
 					name: user.id
 				}, type, config));
 			}


### PR DESCRIPTION
fix this :
![image](https://github.com/mwittrien/BetterDiscordAddons/assets/7073622/d0e13c71-7ca7-4543-9e2b-d2cb953740b6)


Plugins was crashing because insertIndex was not defined, since it wasn't a part of the Args I've removed it.