### PR TITLE
fix css issue

### DIFF
--- a/Plugins/CharCounter/CharCounter.plugin.js
+++ b/Plugins/CharCounter/CharCounter.plugin.js
@@ -94,6 +94,7 @@ module.exports = (_ => {
 				this.css = `
 					${BDFDB.dotCN._charcountercounteradded} {
 						position: relative !important;
+      						width: 100%;
 					}
 					${BDFDB.dotCN._charcountercounter} {
 						display: block;


### PR DESCRIPTION
fixes a bug in the css that causes the CharCounter plugin to shrink your text box down as small as possible. see below for an image of the current effect 
![image](https://github.com/mwittrien/BetterDiscordAddons/assets/74981904/091874a5-d0e7-4ead-8f71-f580a31ff1d8)
