### PR TITLE
fix: Settings Modal `close button` to be clickable

### DIFF
--- a/Themes/SettingsModal/SettingsModal.css
+++ b/Themes/SettingsModal/SettingsModal.css
@@ -105,21 +105,21 @@
 }
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d .closeButton_df5532 {
 	border: none !important;
-	border-radius: 0 !important;
-	width: 100% !important;
-	max-width: unset !important;
-	height: 100% !important;
-	max-height: unset !important;
-	cursor: default !important;
-	flex: unset !important;
-	transition: unset !important;
-	&:hover {
-	        transition: unset !important;
-	        background: unset !important;
-	}
-        > svg {
-		display: none !important;
-        }
+    border-radius: 0 !important;
+    width: 100% !important;
+    max-width: unset !important;
+    height: 100% !important;
+    max-height: unset !important;
+    cursor: default !important;
+    flex: unset !important;
+    transition: unset !important;
+    &:hover {
+        transition: unset !important;
+        background: unset !important;
+    }
+    > svg {
+        display: none !important;
+    }
 }
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d {
     position: fixed !important;

--- a/Themes/SettingsModal/SettingsModal.css
+++ b/Themes/SettingsModal/SettingsModal.css
@@ -99,36 +99,49 @@
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .standardSidebarView_c25c6d .editor {
 	height: calc(var(--settingsheight_v) - 120px) !important;
 }
-#app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d,
-#app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d .tools_c25c6d,
-#app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d .container_df5532,
+#app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d .tools_c25c6d {
+    width: 100% !important;
+    height: 100% !important;
+}
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d .closeButton_df5532 {
-	position: absolute !important;
-	top: 0 !important;
-	right: 0 !important;
-	bottom: 0 !important;
-	left: 0 !important;
-	background: transparent !important;
 	border: none !important;
 	border-radius: 0 !important;
 	width: 100% !important;
 	max-width: unset !important;
 	height: 100% !important;
 	max-height: unset !important;
-	margin: 0 !important;
-	padding: 0 !important;
-	opacity: 0 !important;
 	cursor: default !important;
+	flex: unset !important;
+	transition: unset !important;
+	&:hover {
+	        transition: unset !important;
+	        background: unset !important;
+	}
+        > svg {
+		display: none !important;
+        }
 }
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .toolsContainer_c25c6d {
-	position: fixed !important;
-	top: 22px !important;
-	z-index: -1 !important;
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100% !important;
+    max-width: unset !important;
+    height: 100% !important;
+    max-height: unset !important;
+    z-index: -1 !important;
+    padding-top: 0 !important;
+}
+#app-mount > .appAsidePanelWrapper_bd26cc > .notAppAsidePanel_bd26cc .contentRegion_c25c6d .toolsContainer_c25c6d {
+    .container_df5532 {
+        height: 100% !important;
+    }
+    .keybind_df5532 {
+        display: none !important;
+    }
 }
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .settingsToolbar_wu4yfQ {
 	display: none !important;
 }
-
 #app-mount .layer_d4b6c5 ~ .layer_d4b6c5 .accountProfileCard_b69b77 {
 	max-width: calc(var(--settingswidth_v) - 332px - var(--settingsiconsadditionalsize)) !important;
 }


### PR DESCRIPTION
Previously, I used it with the `AlwaysAnimate` plugin; not sure that was the problem, but I can't click outside of the modal to close it; it just works if I'm lucky enough.

So here's what this PR does:
- Edit some css for the modal's close button to be filled with full width and height, also with `flex` property set to `unset`.
- Disable `transition` and `background` changing when hovering close button.
- Reduced some unnecessary selector.

Now it works without any luck needed.

Edit: This PR changed nothing about visual display (like showing the close button); just fix the hit-box of the close button.