### PR TITLE
Removed the option to change the emojis in the code and added a plugin to easily manage the emoji provider with a drop down.

### DIFF
--- a/Plugins/EmojiReplaceSettings.plugin.js
+++ b/Plugins/EmojiReplaceSettings.plugin.js
@@ -1,0 +1,108 @@
+/**
+ * @name EmojiReplaceSettings
+ * @description Adds a settings menu to select different emoji providers for the theme EmojiReplace by DevilBro.
+ * @author AidanTheDev
+ * @version 1.0.0
+ */
+
+module.exports = (() => {
+	const config = {
+		info: {
+			name: "EmojiReplaceSettings",
+			authors: [{ name: "AidanTheDev" }],
+			version: "1.0.0",
+			description: "Adds a settings menu to select different emoji providers for the theme EmojiReplace by DevilBro."
+		}
+	};
+
+	return class {
+		constructor() {
+			this.emojiProviders = [
+				"Apple", "BlobMoji", "Facebook", "Google", "Huawei",
+				"JoyPixels", "Microsoft", "Microsoft-3D", "OpenMoji",
+				"Samsung", "Samsung-Old", "Toss", "WhatsApp"
+			];
+		}
+
+		// Function to inject emoji provider stylesheet
+		setEmojiProvider(provider) {
+			// Remove existing emoji styles
+			document.querySelectorAll("link[data-emoji-provider]").forEach(link => link.remove());
+
+			// Create a new <link> element
+			const link = document.createElement("link");
+			link.rel = "stylesheet";
+			link.href = `https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/base/${provider}.css`;
+			link.setAttribute("data-emoji-provider", provider);
+
+			// Append to head
+			document.head.appendChild(link);
+		}
+
+		// Load saved settings or default to Samsung
+		loadSettings() {
+			const savedProvider = BdApi.loadData(config.info.name, "emojiProvider") || "Samsung";
+			this.setEmojiProvider(savedProvider);
+		}
+
+		// Save the selected provider
+		saveSettings(provider) {
+			BdApi.saveData(config.info.name, "emojiProvider", provider);
+			this.setEmojiProvider(provider);
+		}
+
+		start() {
+			this.loadSettings();
+		}
+
+		stop() {
+			document.querySelectorAll("link[data-emoji-provider]").forEach(link => link.remove());
+		}
+
+		// Adds the settings menu to BetterDiscord
+		getSettingsPanel() {
+			const panel = document.createElement("div");
+			panel.style.padding = "10px";
+			panel.style.backgroundColor = "#36393f";
+			panel.style.borderRadius = "8px";
+			panel.style.boxShadow = "0 2px 5px rgba(0, 0, 0, 0.3)";
+
+			// Label styling
+			const label = document.createElement("label");
+			label.textContent = "Select Emoji Provider:";
+			label.style.color = "#ffffff";
+			label.style.fontSize = "14px";
+			label.style.fontWeight = "bold";
+			panel.appendChild(label);
+
+			// Dropdown (select) styling
+			const select = document.createElement("select");
+			select.style.marginLeft = "10px";
+			select.style.padding = "5px";
+			select.style.backgroundColor = "#2f3136";
+			select.style.border = "1px solid #4f545c";
+			select.style.borderRadius = "5px";
+			select.style.color = "#ffffff";
+			select.style.fontSize = "14px";
+			select.style.cursor = "pointer";
+
+			this.emojiProviders.forEach(provider => {
+				const option = document.createElement("option");
+				option.value = provider;
+				option.textContent = provider;
+				select.appendChild(option);
+			});
+
+			// Load saved selection
+			select.value = BdApi.loadData(config.info.name, "emojiProvider") || "Samsung";
+
+			select.addEventListener("change", () => {
+				this.saveSettings(select.value);
+			});
+
+			// Add the dropdown to the panel
+			panel.appendChild(select);
+			return panel;
+		}
+	};
+})();

--- a/Themes/EmojiReplace/EmojiReplace.theme.css
+++ b/Themes/EmojiReplace/EmojiReplace.theme.css
@@ -1,6 +1,6 @@
 /**
  * @name EmojiReplace
- * @description Replaces Discord's Emojis with Emojis of a different Provider (Apple, Facebook...)
+ * @description Replaces Discord's Emojis with a selected provider. Requires the EmojiReplaceSettings plugin for customization.
  * @author DevilBro
  * @version 1.0.0
  * @authorId 278543574059057154
@@ -10,35 +10,8 @@
  * @website https://mwittrien.github.io/
  * @source https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/EmojiReplace/
  * @updateUrl https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/EmojiReplace.theme.css
- */
-
-/*
-	!!READ THIS!!
-	
-	This theme lets you swap the default emojis of discord with the emojis of a provider of your choice.
-	To change the provider simply swap the marked word in the import url down below with a supported provider listed below.
-	The name of the provider is CASE SENSITIVE, meaning you have to write it exactly like it's written below.
-	Correct: Apple
-	False: apple, APPLE, aPpLe
-	
-	Supported Providers:
-		→ Apple
-		→ BlobMoji
-		→ Facebook
-		→ Google
-		→ Huawei
-		→ JoyPixels
-		→ Microsoft
-		→ Microsoft-3D
-		→ OpenMoji
-		→ Samsung
-		→ Samsung-Old
-		→ Toss
-		→ WhatsApp
 */
 
-/*										   REPLACE THIS			*/
-/*										     ↓↓↓↓↓			*/
-@import url(https://mwittrien.github.io/BetterDiscordAddons/Themes/EmojiReplace/base/Apple.css);
-/*										     ↑↑↑↑↑		  	*/
-/*										   REPLACE THIS			*/
+ :root {
+	--emoji-provider: "Samsung"; /* Default */
+}


### PR DESCRIPTION
So, most people that use BD don't know how to code so I thought instead of going into the code to edit the emoji provider instead I'd edit the code to work with a plugin that just uses a dropdown to control which emojis you have. It doesn't necessarily have to take the place of the current theme but maybe it could be an additional theme with the plugin included. This is just something I made myself out of the annoyance of having to go into the code everytime I wanted to change the emoji and didn't want to upload it on my own since this theme wasn't my idea.