### PR TITLE
NotificationsSounds: Play If Muted feature + suppression fix

### DIFF
--- a/Plugins/NotificationSounds/NotificationSounds.plugin.js
+++ b/Plugins/NotificationSounds/NotificationSounds.plugin.js
@@ -2,7 +2,7 @@
  * @name NotificationSounds
  * @author DevilBro
  * @authorId 278543574059057154
- * @version 4.1.0
+ * @version 4.1.1
  * @description Allows you to replace the native Sounds with custom Sounds
  * @invite Jx3TjNS
  * @donate https://www.paypal.me/MircoWittrien
@@ -261,6 +261,7 @@ module.exports = (_ => {
 							const isCurrent = BDFDB.LibraryStores.SelectedChannelStore.getChannelId() == channel.id;
 							const isGroupDM = channel.isGroupDM();
 							const isThread = BDFDB.ChannelUtils.isThread(channel);
+							const isCurrentAndFocused = isCurrent & document.hasFocus()
 							
 							if (!toggles.playIfMuted) {
 								if ((isThread && BDFDB.LibraryStores.JoinedThreadsStore.isMuted(channel.id)) || (!isThread && BDFDB.LibraryStores.UserGuildSettingsStore.isGuildOrCategoryOrChannelMuted(guildId, channel.id))) return;
@@ -273,7 +274,7 @@ module.exports = (_ => {
 							}
 							else if (!guildId) {
 								this.fireEvent(isGroupDM ? "groupdm" : "dm");
-								(!isCurrent || !document.hasFocus()) && this.playAudio(isGroupDM ? "groupdm" : "dm");
+								!isCurrentAndFocused && this.playAudio(isGroupDM ? "groupdm" : "dm");
 								return;
 							}
 							else if (guildId) {
@@ -281,12 +282,12 @@ module.exports = (_ => {
 									if (message.mentions.length && !this.isSuppressMentionsEnabled(guildId, channel.id)) for (const mention of message.mentions) if (mention.id == BDFDB.UserUtils.me.id) {
 										if (message.message_reference && !message.interaction) {
 											this.fireEvent("reply");
-											!isCurrent && this.playAudio("reply");
+											!isCurrentAndFocused && this.playAudio("reply");
 											return;
 										}
 										if (!message.message_reference) {
 											this.fireEvent("mentioned");
-											!isCurrent && this.playAudio("mentioned");
+											!isCurrentAndFocused && this.playAudio("mentioned");
 											return;
 										}
 									}
@@ -294,26 +295,26 @@ module.exports = (_ => {
 										const member = BDFDB.LibraryStores.GuildMemberStore.getMember(guildId, BDFDB.UserUtils.me.id);
 										if (member && member.roles.length) for (const roleId of message.mention_roles) if (member.roles.includes(roleId)) {
 											this.fireEvent("role");
-											!isCurrent && this.playAudio("role");
+											!isCurrentAndFocused && this.playAudio("role");
 											return;
 										}
 									}
 									if (message.mention_everyone && !BDFDB.LibraryStores.UserGuildSettingsStore.isSuppressEveryoneEnabled(guildId, channel.id)) {
 										if (message.content.indexOf("@everyone") > -1) {
 											this.fireEvent("everyone");
-											!isCurrent && this.playAudio("everyone");
+											!isCurrentAndFocused && this.playAudio("everyone");
 											return;
 										}
 										if (message.content.indexOf("@here") > -1) {
 											this.fireEvent("here");
-											!isCurrent && this.playAudio("here");
+											!isCurrentAndFocused && this.playAudio("here");
 											return;
 										}
 									}
 								}
 								if (BDFDB.LibraryStores.UserGuildSettingsStore.allowAllMessages(channel) && !(isThread && !BDFDB.LibraryStores.JoinedThreadsStore.hasJoined(channel.id))) {
 									this.fireEvent("message1");
-									!isCurrent && this.playAudio("message1");
+									!isCurrentAndFocused && this.playAudio("message1");
 									return;
 								}
 							}


### PR DESCRIPTION
Hi. Thanks for great job on extending Discord. I wanted to improve my configuration and came to your library. This plugin gave me what I wanted, but not at 100%, so I decided to investigate how I can extend it

Here is two changes. One is to add new feature, second is to fix an issue. I just combined it to single PR, but you can check commits for them separately. They are not related to each other

###### Feature
What I wanted to achieve is to make Discord notify me by red badge and sound when I got mentioned. To make it work with red mark, you have to mute server/channel. If it is not muted, Discord shows red mark for any new regular message, disregarding notification settings, whether it is 'All Messages' or 'Only @mentions'. So, I basically have all servers muted. So, the new option simply adds the ability to skip the mute check

###### Issue
If you have `Enable same-channel message notifications` in Notification settings `off`, enabling plugin starts to suppress sounds for messages in current channel, even if Discord is minimized. This differs from how Discord handles this. It suppresses sound only if the message is in current channel and application is focused. So I have added new const for this flag and used it where it should be. Actually it was right in one place, but wrong in six others. Let me know if this is not right and we need a separate option to control this, I can work on it