### PR TITLE
NotificationSounds: fix & => && typo

### DIFF
--- a/Plugins/NotificationSounds/NotificationSounds.plugin.js
+++ b/Plugins/NotificationSounds/NotificationSounds.plugin.js
@@ -261,7 +261,7 @@ module.exports = (_ => {
 							const isCurrent = BDFDB.LibraryStores.SelectedChannelStore.getChannelId() == channel.id;
 							const isGroupDM = channel.isGroupDM();
 							const isThread = BDFDB.ChannelUtils.isThread(channel);
-							const isCurrentAndFocused = isCurrent & document.hasFocus()
+							const isCurrentAndFocused = isCurrent && document.hasFocus();
 							
 							if (!toggles.playIfMuted) {
 								if ((isThread && BDFDB.LibraryStores.JoinedThreadsStore.isMuted(channel.id)) || (!isThread && BDFDB.LibraryStores.UserGuildSettingsStore.isGuildOrCategoryOrChannelMuted(guildId, channel.id))) return;


### PR DESCRIPTION
Hi! Thanks for merging #2934
I just reviewed it once again and found that I used bitwise & instead of &&. It works the same for bools, but here is a fix to make it correct