### PR TITLE
Fix font size being overriden by Oldcord

### DIFF
--- a/Plugins/ReadAllNotificationsButton/ReadAllNotificationsButton.plugin.js
+++ b/Plugins/ReadAllNotificationsButton/ReadAllNotificationsButton.plugin.js
@@ -176,7 +176,7 @@ module.exports = (_ => {
 					#app-mount ${BDFDB.dotCN._readallnotificationsbuttonframe},
 					#app-mount ${BDFDB.dotCN._readallnotificationsbuttoninner},
 					#app-mount ${BDFDB.dotCN._readallnotificationsbuttonbutton} {
-						height: 24px;
+						height: 24px !important;
 					}
 					${BDFDB.dotCN._readallnotificationsbuttonbutton} {
 						border-radius: 4px;


### PR DESCRIPTION
The OldCord theme has this in its CSS to force buttons to be 50px in height again:

https://github.com/milbits/oldcord/blob/b267999f4ed59633c40e93f6a64a0c2648ef44c9/src/components/redesign.css#L328

By adding !important to below, we can override this:

https://github.com/mwittrien/BetterDiscordAddons/blob/3a75d417832c33a6b4914e9a7d68e57aab6e2f14/Plugins/ReadAllNotificationsButton/ReadAllNotificationsButton.plugin.js#L179

Not sure if this would be something Oldcord should fix or not, since they likely use !important to override the shitty discord redesign CSS in the first place

Edit: I guess I'm a bit wrong in the title, I meant the "box" size. Font is fine, the box itself gets set to be 50px in height though for the button.