### PR TITLE
Refactor openInSteam method

### DIFF
--- a/Plugins/OpenSteamLinksInApp/OpenSteamLinksInApp.plugin.js
+++ b/Plugins/OpenSteamLinksInApp/OpenSteamLinksInApp.plugin.js
@@ -2,7 +2,7 @@
  * @name OpenSteamLinksInApp
  * @author DevilBro
  * @authorId 278543574059057154
- * @version 1.1.7
+ * @version 1.1.8
  * @description Opens Steam Links in Steam instead of your Browser
  * @invite Jx3TjNS
  * @donate https://www.paypal.me/MircoWittrien
@@ -105,16 +105,11 @@ module.exports = (_ => {
 				return false;
 			}
 
-			openInSteam (url) {
-				const xhr = new XMLHttpRequest();
-				xhr.open("GET", url, true);
-				xhr.onreadystatechange = function () {
-					if (xhr.readyState != 4) return;
-					let responseUrl = xhr.responseURL || url;
-					if (BDFDB.LibraryRequires.electron.shell.openExternal("steam://openurl/" + responseUrl));
-					else BDFDB.DiscordUtils.openLink(responseUrl);
-				};
-				xhr.send(null);
+			async openInSteam (url) {
+				const res = await BdApi.Net.fetch(url)
+				let responseUrl = res.url || url;
+				if (BDFDB.LibraryRequires.electron.shell.openExternal("steam://openurl/" + responseUrl));
+				else BDFDB.DiscordUtils.openLink(responseUrl);
 			}
 		};
 	})(window.BDFDB_Global.PluginUtils.buildPlugin(changeLog));


### PR DESCRIPTION
Changed the xhr, as it was not achieving the redirection because of a CORS problem.

Whenever we tried to open a https://s.team link, it was opened on our browser instead of the actual steam app.
The problem was that the redirection never occured because of CORS, and we weren´t getting any redirection URL.
<img width="993" height="62" alt="image" src="https://github.com/user-attachments/assets/c2fc26d9-62d6-48eb-8a92-1b63f614c493" />

Changing the XHR with a fetch solved CORS, and let the link redirect us again.
