### PR TITLE
NotificationSounds: update playIfMuted setting

### DIFF
--- a/Plugins/NotificationSounds/NotificationSounds.plugin.js
+++ b/Plugins/NotificationSounds/NotificationSounds.plugin.js
@@ -182,7 +182,7 @@ module.exports = (_ => {
 						globalVolume:		{value: 100,	description: "Global Notification Sounds Volume"}
 					},
 					toggles: {
-						playIfMuted: 		{value: false,	description: "Play Sounds Of Muted Channels/Servers"}
+						playIfChannelIsMuted: 		{value: false,	description: "Play Sounds Of Muted Channels/Servers"}
 					}
 				};
 				
@@ -270,7 +270,7 @@ module.exports = (_ => {
 							const isThread = BDFDB.ChannelUtils.isThread(channel);
 							const isCurrentAndFocused = isCurrent && document.hasFocus();
 							
-							if (!toggles.playIfMuted) {
+							if (!toggles.playIfChannelIsMuted) {
 								if ((isThread && BDFDB.LibraryStores.JoinedThreadsStore.isMuted(channel.id)) || (!isThread && BDFDB.LibraryStores.UserGuildSettingsStore.isGuildOrCategoryOrChannelMuted(guildId, channel.id))) return;
 							}
 							


### PR DESCRIPTION
Hi, the setting we have added by https://github.com/mwittrien/BetterDiscordAddons/pull/2934 is stable, I'm still using it, but I just noticed that its name is ambiguous compared to the individual sound settings like `Mute in DND`, `Mute in Invisible`, `Mute when playing`.
Currently, it sounds like it overrides them. Lets update the name to make it more clear what it does