### PR TITLE
Needlessly rebuilt every render

### DIFF
--- a/Plugins/Translator/Translator.plugin.js
+++ b/Plugins/Translator/Translator.plugin.js
@@ -1079,7 +1079,6 @@ module.exports = (_ => {
 			}
 
 			getLanguageChoice (direction, place, channelId) {
-				this.setLanguages();
 				let choice;
 				let channel = channelId && BDFDB.LibraryStores.ChannelStore.getChannel(channelId);
 				let guildId = channel ? (channel.guild_id ? channel.guild_id : "@me") : null;


### PR DESCRIPTION
It's redundant since anything that changes state already calls `setLanguages()` directly