### PR TITLE
Sidebar vanishing

### DIFF
--- a/Library/0BDFDB.plugin.js
+++ b/Library/0BDFDB.plugin.js
@@ -3851,7 +3851,7 @@ module.exports = (_ => {
 							let hidden = BDFDB.DOMUtils.isHidden(hideNode);
 							if (hidden) {
 								BDFDB.DOMUtils.toggle(hideNode, true);
-								hideNode.BDFDBgetRectsHidden = true;
+								if (!BDFDB.DOMUtils.isHidden(hideNode)) hideNode.BDFDBgetRectsHidden = true;
 							}
 							hideNode = hideNode.parentElement;
 						}


### PR DESCRIPTION
Fixes https://github.com/mwittrien/BetterDiscordAddons/issues/3220

getRects adds an inline display: none !important that sticks after the CSS class is removed. Just verify the the element actually became visible first. Tested with SpotifyControls