### PR TITLE
[IMPROVEMENT] - Translator: Add OpenAI compatible translation engine

### DIFF
--- a/Plugins/Translator/Translator.plugin.js
+++ b/Plugins/Translator/Translator.plugin.js
@@ -514,7 +514,7 @@ module.exports = (_ => {
 										BDFDB.ReactUtils.createElement(BDFDB.LibraryComponents.FormTitle.Title, {
 											className: BDFDB.disCN.marginbottom8,
 											tag: BDFDB.LibraryComponents.FormTitle.Tags.H5,
-											children: "OAI Compatible"
+											children: translationEngines[key].name || "OAI Compatible"
 										}),
 										BDFDB.ReactUtils.createElement(BDFDB.LibraryComponents.CollapseContainer, {
 											title: "custom",
@@ -1498,13 +1498,18 @@ module.exports = (_ => {
 							callback("");
 						}
 					} else {
-						if (response.statusCode == 401 || response.statusCode == 403) {
+						if (response && response.statusCode == 401 || response.statusCode == 403) {
 							BDFDB.NotificationUtils.toast(`${this.labels.toast_translating_failed}. ${this.labels.toast_translating_tryanother}. ${this.labels.error_keyoutdated}`, {
 								type: "danger",
 								position: "center"
 							});
-						} else if (response.statusCode == 429) {
+						} else if (response && response.statusCode == 429) {
 							BDFDB.NotificationUtils.toast(`${this.labels.toast_translating_failed}. ${this.labels.toast_translating_tryanother}. ${this.labels.error_dailylimit}`, {
+								type: "danger",
+								position: "center"
+							});
+						} else if (error) {
+							BDFDB.NotificationUtils.toast(`${this.labels.toast_translating_failed}. ${this.labels.toast_translating_tryanother}. ${error.message || this.labels.error_serverdown}`, {
 								type: "danger",
 								position: "center"
 							});


### PR DESCRIPTION
I added an OpenAI-compatible translation engine as an additional option, allowing users to choose their preferred LLM for translation more freely, rather than being limited to using only deepseek.  
I tested it with siliconflow’s free Tencent/Hunyuan-MT-7B, which is an LLM specifically designed for translation tasks and works much faster than deepseek. The API for accessing this model is: https://api.siliconflow.cn/v1/chat/completions. It seems that my modifications have worked as expected.  
I also tested kimi-k2-0905-preview, using the API: https://api.moonshot.cn/v1/chat/completions, and it functioned correctly too.