### PR TITLE
Update model name in Translator.plugin.js to deepseek-v4-flash

### DIFF
--- a/Plugins/Translator/Translator.plugin.js
+++ b/Plugins/Translator/Translator.plugin.js
@@ -1465,7 +1465,7 @@ module.exports = (_ => {
 				`;
 
 				const requestData = {
-					model: "deepseek-chat",
+					model: "deepseek-v4-flash",
 					messages: [{
 						role: "system",
 						content: "You are a senior bilingual localization specialist"


### PR DESCRIPTION
[The model names deepseek-chat and deepseek-reasoner will be deprecated on 2026/07/24. ](https://api-docs.deepseek.com/)
So to avoid API call errors when the time comes, I suggest preemptively modify it now