### PR TITLE
To avoid serious timeouts in the DeepSeek translator

### DIFF
--- a/Plugins/Translator/Translator.plugin.js
+++ b/Plugins/Translator/Translator.plugin.js
@@ -1474,7 +1474,10 @@ module.exports = (_ => {
 						content: translationPrompt
 					}],
 					temperature: 0.2,
-					top_p: 0.8
+					top_p: 0.8,
+					thinking: {
+						type: "disabled"
+					}
 				};
 
 				BDFDB.LibraryRequires.request("https://api.deepseek.com/v1/chat/completions", {


### PR DESCRIPTION
According to the DeepSeek documentation, the DeepSeek API uses think mode by default, which significantly increases the translation time and causes timeouts.