### PR TITLE
Fix: Handle NotificationSounds Notification Arguments Safely

### DIFF
--- a/Plugins/NotificationSounds/NotificationSounds.plugin.js
+++ b/Plugins/NotificationSounds/NotificationSounds.plugin.js
@@ -330,8 +330,8 @@ module.exports = (_ => {
 				}});
 				
 				BDFDB.PatchUtils.patch(this, BDFDB.LibraryModules.DesktopNotificationUtils, "showNotification", {before: e => {
-					let soundObjIndex = Array.from(e.methodArguments).findIndex(n => n && n.sound);
-					if (soundObjIndex && e.methodArguments[soundObjIndex].sound.includes("message")) e.methodArguments[soundObjIndex].sound = null;
+					const soundObj = Array.from(e.methodArguments).find(n => n && typeof n.sound == "string");
+					if (soundObj && soundObj.sound.includes("message")) soundObj.sound = null;
 				}});
 				if (BDFDB.LibraryModules.SoundUtils && BDFDB.LibraryModules.SoundUtils.createSound) {
 					let cancel = BDFDB.PatchUtils.patch(this, BDFDB.LibraryModules.SoundUtils, "createSound", {after: e => {


### PR DESCRIPTION
## Summary

Prevents NotificationSounds from crashing when Discord changes the position or shape of the notification sound argument.

## What changed

- Locate the notification argument by its string `sound` property.
- Clear Discord's default message sound only when that argument exists.
- Avoid reading `sound` from an undefined argument.

## Root cause

- The patch assumed the sound payload was always at one argument index.
- Current Discord notification calls no longer preserve that assumption.

## Impact

NotificationSounds can intercept message notifications without throwing from its `showNotification` callback.

## Validation

- `node --check Plugins/NotificationSounds/NotificationSounds.plugin.js`
- `git diff --check upstream/master..HEAD`
- Reloaded in Discord without reproducing the original notification callback error.
