### PR TITLE
Fix: Restore PinDMs Channel-List Sections

### DIFF
--- a/Plugins/PinDMs/PinDMs.plugin.js
+++ b/Plugins/PinDMs/PinDMs.plugin.js
@@ -84,13 +84,9 @@ module.exports = (_ => {
 				};
 				
 				this.modulePatches = {
-					before: [
-						"PrivateChannelsList"
-					],
 					after: [
 						"DirectMessage",
-						"PrivateChannel",
-						"PrivateChannelsList"
+						"PrivateChannel"
 					],
 					componentDidMount: [
 						"DirectMessage"
@@ -179,11 +175,13 @@ module.exports = (_ => {
 				}});
 				
 				pinnedChannels = BDFDB.DataUtils.load(this, "pinned", BDFDB.UserUtils.me.id) || {};
+				this.patchPrivateChannelsList();
 				
 				this.forceUpdateAll();
 			}
 			
 			onStop () {
+				clearTimeout(this.privateChannelsListPatchTimer);
 				this.forceUpdateAll();
 			}
 
@@ -858,12 +856,42 @@ module.exports = (_ => {
 							channelListIsRenderendering = true;
 							BDFDB.TimeUtils.timeout(_ => channelListIsRenderendering = false, 3000);
 						}
-						else BDFDB.PatchUtils.forceAllUpdates(this, "PrivateChannelsList");
+						const instance = this.getPrivateChannelsListInstance();
+						if (instance) BDFDB.ReactUtils.forceUpdate(instance);
+						else this.patchPrivateChannelsList();
 						break;
 					case "guildList":
 						BDFDB.DiscordUtils.rerenderAll(true);
 						break;
 				}
+			}
+
+			getPrivateChannelsListInstance () {
+				const list = document.querySelector('nav[class*="privateChannels"] ul');
+				return list && BDFDB.ReactUtils.findOwner(list, {
+					up: true,
+					unlimited: true,
+					filter: fiber => fiber.stateNode && fiber.stateNode.props && Array.isArray(fiber.stateNode.props.privateChannelIds) && typeof fiber.stateNode.renderDM == "function" && typeof fiber.stateNode.renderRow == "function"
+				});
+			}
+
+			patchPrivateChannelsList () {
+				clearTimeout(this.privateChannelsListPatchTimer);
+				const instance = this.getPrivateChannelsListInstance();
+				const prototype = instance && Object.getPrototypeOf(instance);
+				if (!prototype || typeof prototype.render != "function") {
+					this.privateChannelsListPatchTimer = setTimeout(_ => this.patchPrivateChannelsList(), 1000);
+					return;
+				}
+				if (!BDFDB.PatchUtils.isPatched(this, prototype, "render")) BDFDB.PatchUtils.patch(this, prototype, "render", {
+					before: e => this.processPrivateChannelsList({instance: e.instance}),
+					after: e => {
+						const event = {instance: e.instance, returnvalue: e.returnValue};
+						this.processPrivateChannelsList(event);
+						return event.returnvalue;
+					}
+				}, {name: "PrivateChannelsList"});
+				BDFDB.ReactUtils.forceUpdate(instance);
 			}
 
 			sortAndUpdate (type) {


### PR DESCRIPTION
## Summary

Restores PinDMs categories in Discord's current virtualized direct-message list and keeps pinned rows in their assigned sections while scrolling.

## What changed

- Resolve the mounted private-channel list from the current React tree.
- Patch its class renderer with the existing PinDMs section-processing logic.
- Retry until the list is mounted and force-update the active list after category changes.
- Remove the stale named `PrivateChannelsList` module hook.

## Root cause

- Discord now renders the class-based private-channel list below a wrapper that the previous named module hook does not reach.
- Without that hook, PinDMs cannot inject its category sections into the virtual list.

## Impact

Pinned categories remain visible and correctly grouped during scrolling, while the normal Direct Messages section stays below them.

## Validation

- `node --check Plugins/PinDMs/PinDMs.plugin.js`
- `git diff --check upstream/master..HEAD`
- Repeatedly scrolled the live Discord DM list; category headers remained stable and pinned DMs did not leak into Direct Messages.
